### PR TITLE
update IAM in ap-terraform-eks-core

### DIFF
--- a/iam_cert_manager.tf
+++ b/iam_cert_manager.tf
@@ -6,7 +6,7 @@ module "iam_assumable_role_cert_manager" {
   create_role                   = true
   role_name_prefix              = "CertManager"
   role_policy_arns              = [aws_iam_policy.cert_manager.arn]
-  provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+  provider_url                  = module.eks.cluster_oidc_issuer_url
   oidc_fully_qualified_subjects = ["system:serviceaccount:cert-manager:cert-manager"]
   tags = {
     cluster = ${var.cluster_name}

--- a/iam_cluster_autoscaler.tf
+++ b/iam_cluster_autoscaler.tf
@@ -6,7 +6,7 @@ module "iam_assumable_role_cluster_autoscaler" {
   create_role                   = true
   role_name_prefix              = "ClusterAutoscaler"
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
-  provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+  provider_url                  = module.eks.cluster_oidc_issuer_url
   oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler"]
   tags = {
     cluster = ${var.cluster_name}

--- a/iam_external_dns.tf
+++ b/iam_external_dns.tf
@@ -6,7 +6,7 @@ module "iam_assumable_role_external_dns" {
   create_role                   = true
   role_name_prefix              = "ExternalDNS"
   role_policy_arns              = [aws_iam_policy.external_dns.arn]
-  provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+  provider_url                  = module.eks.cluster_oidc_issuer_url
   oidc_fully_qualified_subjects = ["system:serviceaccount:external-dns:external-dns"]
   tags = {
     cluster = ${var.cluster_name}

--- a/iam_external_secrets.tf
+++ b/iam_external_secrets.tf
@@ -6,7 +6,7 @@ module "iam_assumable_role_external_secrets" {
   create_role                   = true
   role_name_prefix              = "ExternalSecrets"
   role_policy_arns              = [aws_iam_policy.external_secrets.arn]
-  provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+  provider_url                  = module.eks.cluster_oidc_issuer_url
   oidc_fully_qualified_subjects = ["system:serviceaccount:external-secrets:external-secrets"]
   tags = {
     cluster = ${var.cluster_name}


### PR DESCRIPTION
**JIRA**: ANPL-1178

## What has changed?

- change roles to use IAM eks-role module
- modify role names prefix to use camel case
- remove cluster name from name prefix and add as a tag
- make the code consistent across all files

## Why is this needed?

There are multiple patterns in which IAM roles have been provisioned across the code base. We are standardising on patterns we maintain in https://github.com/ministryofjustice/ap-terraform-iam-roles  See that [README.md](http://readme.md/) for more detail.

## What should the reviewer concentrate on?

- sanity check
- changes satisfy the ticket requirements