### PR TITLE
fix: modify module in line with the in house IAM module

### DIFF
--- a/iam_cert_manager.tf
+++ b/iam_cert_manager.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_cert_manager" {
   role_description         = "cert-manager role for cluster ${module.eks.cluster_id}"
   role_policy_arns         = [aws_iam_policy.cert_manager.arn]
   provider_url             = module.eks.cluster_oidc_issuer_url
-  cluster_service_accounts = ["cert-manager"]
+  cluster_service_accounts = ["cert-manager:cert-manager"]
   tags = {
     cluster = var.cluster_name
   }

--- a/iam_cluster_autoscaler.tf
+++ b/iam_cluster_autoscaler.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_cluster_autoscaler" {
   role_description         = "EKS cluster-autoscaler role for cluster ${module.eks.cluster_id}"
   role_policy_arns         = [aws_iam_policy.cluster_autoscaler.arn]
   provider_url             = module.eks.cluster_oidc_issuer_url
-  cluster_service_accounts = ["cluster-autoscaler"]
+  cluster_service_accounts = ["cluster-autoscaler:cluster-autoscaler"]
   tags = {
     cluster = var.cluster_name
   }

--- a/iam_external_dns.tf
+++ b/iam_external_dns.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_external_dns" {
   role_description         = "external dns role for cluster ${module.eks.cluster_id}"
   role_policy_arns         = [aws_iam_policy.external_dns.arn]
   provider_url             = module.eks.cluster_oidc_issuer_url
-  cluster_service_accounts = ["sexternal-dns"]
+  cluster_service_accounts = ["external-dns:external-dns"]
   tags = {
     cluster = var.cluster_name
   }

--- a/iam_external_secrets.tf
+++ b/iam_external_secrets.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_external_secrets" {
   role_description         = "external_secrets role for cluster ${module.eks.cluster_id}"
   role_policy_arns         = [aws_iam_policy.external_secrets.arn]
   provider_url             = module.eks.cluster_oidc_issuer_url
-  cluster_service_accounts = ["external-secrets"]
+  cluster_service_accounts = ["external-secrets:external-secrets"]
   tags = {
     cluster = var.cluster_name
   }


### PR DESCRIPTION
**JIRA**: ANPL-1178

## What has changed?

- changed parameters to reflect the ones used by the ap-terraform-eks-core module

## Why is this needed?

- module will not work with the hashicorp module parameters

## What should the reviewer concentrate on?

- sanity check
- the parameters are in line with the parameter required by the ap-terraform-eks-core module
- the default value for some of the parameters from ap-terraform-eks-core are relevant for this module
