### PR TITLE
fix: use correct outputs from upstream module

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -11,9 +11,9 @@ output "cluster_oidc_issuer_url" {
 output "cluster_role_arns" {
   description = "ARNS of the roles created to support core K8S components"
   value = {
-    external_dns     = module.iam_assumable_role_external_dns.this_iam_role_arn
-    external_secrets = module.iam_assumable_role_external_secrets.this_iam_role_arn
-    autoscaler       = module.iam_assumable_role_cluster_autoscaler.this_iam_role_arn
-    cert_manager     = module.iam_assumable_role_cert_manager.this_iam_role_arn
+    external_dns     = module.iam_assumable_role_external_dns.iam_role_arn
+    external_secrets = module.iam_assumable_role_external_secrets.iam_role_arn
+    autoscaler       = module.iam_assumable_role_cluster_autoscaler.iam_role_arn
+    cert_manager     = module.iam_assumable_role_cert_manager.iam_role_arn
   }
 }


### PR DESCRIPTION
**JIRA**: ANPL-1178

## What has changed?

Use outputs from the ap-terraform-iam-roles module

## Why is this needed?

Outputs from ap-terraform-iam-roles have different naming

## What should the reviewer concentrate on?

- sanity check
- check outputs are correct