### PR TITLE
fix: don't manage kube_proxy as it's deployed by default with new clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
 | Name | Type |
 |------|------|
 | [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.kube_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_iam_policy.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -47,7 +46,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_coredns_version"></a> [cluster\_coredns\_version](#input\_cluster\_coredns\_version) | Version of the CoreDNS add on | `string` | n/a | yes |
-| <a name="input_cluster_kube_proxy_version"></a> [cluster\_kube\_proxy\_version](#input\_cluster\_kube\_proxy\_version) | Version of the KubeProxy add on | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The K8S version of the EKS control plane to provision | `string` | n/a | yes |
 | <a name="input_cluster_node_group_version"></a> [cluster\_node\_group\_version](#input\_cluster\_node\_group\_version) | The K8S version of the EKS node group to provision | `string` | n/a | yes |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The K8S version of the EKS control plane to provision | `string` | n/a | yes |

--- a/addons.tf
+++ b/addons.tf
@@ -8,16 +8,6 @@ resource "aws_eks_addon" "coredns" {
   resolve_conflicts = "OVERWRITE"
 }
 
-resource "aws_eks_addon" "kube_proxy" {
-  depends_on = [
-    module.eks
-  ]
-  addon_name        = "kube-proxy"
-  addon_version     = var.cluster_kube_proxy_version
-  cluster_name      = module.eks.cluster_id
-  resolve_conflicts = "OVERWRITE"
-}
-
 resource "aws_eks_addon" "vpc_cni" {
   depends_on = [
     module.eks

--- a/variables.tf
+++ b/variables.tf
@@ -37,11 +37,6 @@ variable "cluster_coredns_version" {
   type        = string
 }
 
-variable "cluster_kube_proxy_version" {
-  description = "Version of the KubeProxy add on"
-  type        = string
-}
-
 variable "main_nodegroup_instance_types" {
   description = "EC2 instance types to be used for the main EKS nodegroup"
   type        = string


### PR DESCRIPTION
**JIRA**: ANPL-1161

## What has changed?

Don't manage the kube_proxy add on explicitly

## Why is this needed?

From EKS version 1.23 the kube_proxy add on is installed by default, and no default version is available.

See https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html

## What should the reviewer concentrate on?

Sanity check