### PR TITLE
feat: add EBS CSI add-on

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -17,3 +17,13 @@ resource "aws_eks_addon" "vpc_cni" {
   cluster_name      = module.eks.cluster_id
   resolve_conflicts = "OVERWRITE"
 }
+
+resource "aws_eks_addon" "ebs_csi" {
+  depends_on = [
+    module.eks
+  ]
+  addon_name        = "ebs-csi"
+  addon_version     = var.cluster_ebs_csi_version
+  cluster_name      = module.eks.cluster_id
+  resolve_conflicts = "OVERWRITE"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,11 @@ variable "cluster_vpc_cni_version" {
   type        = string
 }
 
+variable "cluster_ebs_csi_version" {
+  description = "Version of the EBS CSI add on"
+  type        = string
+}
+
 variable "cluster_coredns_version" {
   description = "Version of the CoreDNS add on"
   type        = string


### PR DESCRIPTION
**JIRA**: ANPL-1225

## What has changed?

Add EBS CSI add-on to the EKS cluster.

## Why is this needed?

This add-on is required by EKS version 1.23 and above in order for the cluster to be able to provision dynamic persistent volume claims

## What should the reviewer concentrate on?

Sanity check