### PR TITLE
fix: add IAM role for the EBS CSI driver

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -20,10 +20,12 @@ resource "aws_eks_addon" "vpc_cni" {
 
 resource "aws_eks_addon" "ebs_csi" {
   depends_on = [
-    module.eks
+    module.eks,
+    module.iam_assumable_role_ebs_csi_driver
   ]
-  addon_name        = "aws-ebs-csi-driver"
-  addon_version     = var.cluster_ebs_csi_version
-  cluster_name      = module.eks.cluster_id
-  resolve_conflicts = "OVERWRITE"
+  addon_name               = "aws-ebs-csi-driver"
+  addon_version            = var.cluster_ebs_csi_version
+  cluster_name             = module.eks.cluster_id
+  resolve_conflicts        = "OVERWRITE"
+  service_account_role_arn = module.iam_assumable_role_ebs_csi_driver.iam_role_arn
 }

--- a/ebs_csi_driver.tf
+++ b/ebs_csi_driver.tf
@@ -1,0 +1,48 @@
+module "iam_assumable_role_ebs_csi_driver" {
+  source = "git@github.com:ministryofjustice/ap-terraform-iam-roles.git//eks-role?ref=v1.3.0"
+  depends_on = [
+    module.eks
+  ]
+  role_name_prefix         = "EbsCsiDriver"
+  role_description         = "ebs_csi_driver role for cluster ${module.eks.cluster_id}"
+  role_policy_arns         = [aws_iam_policy.ebs_csi_driver.arn]
+  provider_url             = module.eks.cluster_oidc_issuer_url
+  cluster_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+  tags = {
+    cluster = var.cluster_name
+  }
+}
+
+resource "aws_iam_policy" "ebs_csi_driver" {
+  depends_on = [
+    module.eks
+  ]
+  name_prefix = "EbsCsiDriver"
+  description = "ebs_csi_driver policy for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.ebs_csi_driver.json
+  tags = {
+    cluster = var.cluster_name
+  }
+}
+
+data "aws_iam_policy_document" "ebs_csi_driver" {
+  statement {
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:CreateSnapshot",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:DeleteSnapshot",
+      "ec2:DeleteTags",
+      "ec2:DeleteVolume",
+      "ec2:DescribeInstances",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DetachVolume"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+    sid       = "EbsCsiDriver"
+  }
+}


### PR DESCRIPTION
**JIRA**: ANPL-1225

## What has changed?

Add an IAM role to allow the EKS EBS CSI driver to manage EBS volumes

## Why is this needed?

Required for the EBS CSI driver to work

## What should the reviewer concentrate on?

Sanity check