### PR TITLE
fix: cluster autoscaler runs in the kube-system namespace

### DIFF
--- a/iam_cluster_autoscaler.tf
+++ b/iam_cluster_autoscaler.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_cluster_autoscaler" {
   role_description         = "EKS cluster-autoscaler role for cluster ${module.eks.cluster_id}"
   role_policy_arns         = [aws_iam_policy.cluster_autoscaler.arn]
   provider_url             = module.eks.cluster_oidc_issuer_url
-  cluster_service_accounts = ["cluster-autoscaler:cluster-autoscaler"]
+  cluster_service_accounts = ["kube-system:cluster-autoscaler"]
   tags = {
     cluster = var.cluster_name
   }


### PR DESCRIPTION
**JIRA**: ANPL-1062

## What has changed?

Cluster autoscaler is deployed in the kube-system namespace, so IAM trust relationship should reflect that

## Why is this needed?

IAM trust relationship points to the wrong namespace

## What should the reviewer concentrate on?

Sanity check